### PR TITLE
Harden curl usage.

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-curl -o- https://raw.githubusercontent.com/SakuraCredit/sub-bootstrap/master/bootstrap.bash | bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/SakuraCredit/sub-bootstrap/master/bootstrap.bash | bash


### PR DESCRIPTION
This patch ensures that `curl` only accepts proper HTTPS connections, and with modern TLS ciphers.

While `curl` connected to GitHub is not high risk, the best means to harden `curl|sh` usage is to invoke the client (`curl`) with settings that close the gaps (man in the middle on port 443, weak SSL or TLS cipher).

By the way, if you want to pass arguments to the bootstrap script, you can do so as follows in the copy/paste instruction:

```sh
curl ... | bash -s - --opt arg
```

Just noting this in case the need arises. Suggestions on the web get rather strange indeed because this syntax is arcane.